### PR TITLE
Fix firebase testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,31 +44,32 @@ jobs:
     - stage: test
       script:
         - bundle exec fastlane test && bundle exec fastlane assemble
-#    - stage: firebase-test
-#      name: "Large androidTests"
-#      if: type != pull_request
-#      script:
-#        - ./git_crypt_unlock.sh || travis_terminate 1
-#        - ./firebase-test-setup.sh || travis_terminate 1
-#        - ./gradlew assembleInternalDebug
-#        - |
-#          echo "y" | gcloud firebase test android run \
-#          --app ./app/build/outputs/apk/internal/debug/app-internal-debug.apk \
-#          --test ./app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk \
-#          --test-targets "size large" \
-#          --device model=NexusLowRes
-#    - stage: firebase-test
-#      name: "Small and Medium androidTests"
-#      script:
-#        - ./git_crypt_unlock.sh || travis_terminate 1
-#        - ./firebase-test-setup.sh || travis_terminate 1
-#        - ./gradlew :app:assembleInternalDebugAndroidTest
-#        - |
-#          echo "y" | gcloud firebase test android run \
-#          --app ./app/build/outputs/apk/internal/debug/app-internal-debug.apk \
-#          --test ./app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk \
-#          --test-targets "size small","size medium" \
-#          --device model=NexusLowRes
+    - stage: firebase-test
+      name: "Large androidTests"
+      if: type != pull_request
+      script:
+        - ./git_crypt_unlock.sh || travis_terminate 1
+        - ./firebase-test-setup.sh || travis_terminate 1
+        - ./gradlew assembleInternalDebug
+        - |
+          echo "y" | gcloud firebase test android run \
+          --app ./app/build/outputs/apk/internal/debug/app-internal-debug.apk \
+          --test ./app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk \
+          --test-targets "size large" \
+          --device model=NexusLowRes
+    - stage: firebase-test
+      name: "Small and Medium androidTests"
+      script:
+        - ./git_crypt_unlock.sh || travis_terminate 1
+        - ./firebase-test-setup.sh || travis_terminate 1
+        - ./gradlew assembleInternalDebug
+        - bundle exec fastlane assemble
+        - |
+          echo "y" | gcloud firebase test android run \
+          --app ./app/build/outputs/apk/internal/debug/app-internal-debug.apk \
+          --test ./app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk \
+          --test-targets "size small","size medium" \
+          --device model=NexusLowRes
     - stage: deploy
       script:
         - ./git_crypt_unlock.sh || travis_terminate 1


### PR DESCRIPTION
Firebase testing portion failed because the gradle build didn't
generate the `app-internal-debug.apk` file.

  ERROR: (gcloud.firebase.test.android.run)
  [./app/build/outputs/apk/internal/debug/app-internal-debug.apk] not found or not accessible

the target `gradlew :app:assembleInternalDebugAndroidTest` doesn't
generate that file but `gradlew assembleInternalDebug` does.