### PR TITLE
Bug/expiration time finished

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
 
     // Local projects
     implementation project(':android-sdk')
+    api project(':researchstack-sdk')
     implementation project(':backbone')
     implementation project(':data')
     implementation project(':sageresearch-mpower')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 
     // Local projects
     implementation project(':android-sdk')
-    api project(':researchstack-sdk')
     implementation project(':backbone')
     implementation project(':data')
     implementation project(':sageresearch-mpower')

--- a/app/src/main/java/org/sagebionetworks/research/mpower/viewmodel/StudyBurstViewModel.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/viewmodel/StudyBurstViewModel.kt
@@ -1,8 +1,10 @@
 package org.sagebionetworks.research.mpower.viewmodel
 
 import android.app.Application
+import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MediatorLiveData
+import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
@@ -38,7 +40,6 @@ import org.threeten.bp.ZoneId
 import org.threeten.bp.ZonedDateTime
 import java.lang.Integer.MAX_VALUE
 import java.text.SimpleDateFormat
-import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
@@ -151,6 +152,16 @@ open class StudyBurstViewModel(app: Application): ScheduleViewModel(app) {
         }.invoke()
         studyBurstLiveData = liveDataChecked
         return liveDataChecked
+    }
+
+    /**
+     * @param lifecycleOwner that previously was observing the return of the liveData() function
+     * @return a new LiveData object that is refreshed based on the current time of day
+     */
+    fun refreshLiveData(lifecycleOwner: LifecycleOwner): LiveData<StudyBurstItem> {
+        liveData().removeObservers(lifecycleOwner)
+        studyBurstLiveData = null
+        return liveData()
     }
 
     /**


### PR DESCRIPTION
This fixes the 14th day bug seen by Josh in https://sagebionetworks.jira.com/browse/AA-380

Previously, a call to ObserveLiveData after the progress expiration was finished, was entering an infinite loop because it kept being triggered and setting up the timer with a negative expiration time which would immediately trigger the call to ObserveLiveData again.  I fixed it by returning null for negative expiration times, and also fixed the transition after expiration expires and you are still on the screen by refreshing the LiveData instead of just re-observing the same object.