### PR TITLE
AA-363

### DIFF
--- a/app/src/main/java/org/sagebionetworks/research/mpower/researchstack/MpResearchStackArchiveFactory.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/researchstack/MpResearchStackArchiveFactory.kt
@@ -1,0 +1,158 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright 2018  Sage Bionetworks. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission. No license is granted to the trademarks of
+ * the copyright holders even if such marks are included in this software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.sagebionetworks.research.mpower.researchstack
+
+import org.joda.time.DateTime
+import org.researchstack.backbone.answerformat.AnswerFormat
+import org.researchstack.backbone.result.Result
+import org.researchstack.backbone.result.StepResult
+import org.sagebionetworks.bridge.data.Archive
+import org.sagebionetworks.bridge.data.ArchiveFile
+import org.sagebionetworks.bridge.data.JsonArchiveFile
+import org.sagebionetworks.bridge.researchstack.survey.SurveyAnswer
+import org.sagebionetworks.research.mpower.research.MpIdentifier
+import org.sagebionetworks.research.mpower.researchstack.framework.MpDataProvider
+import org.sagebionetworks.research.mpower.researchstack.framework.MpDataProvider.RESULT_IDENTIFIER_MPOWER_1_EMAIL
+import org.sagebionetworks.research.mpower.researchstack.framework.MpTaskHelper
+import org.sagebionetworks.research.mpower.researchstack.framework.step.body.MpBooleanAnswerFormat
+import org.sagebionetworks.research.mpower.researchstack.framework.step.body.MpChoiceAnswerFormat
+import org.sagebionetworks.research.mpower.researchstack.framework.step.body.MpIntegerAnswerFormat
+import org.sagebionetworks.research.mpower.researchstack.framework.step.body.MpTextQuestionBody
+import org.sagebionetworks.research.sageresearch.viewmodel.ResearchStackUploadArchiveFactory
+import org.slf4j.LoggerFactory
+
+open class MpResearchStackArchiveFactory: ResearchStackUploadArchiveFactory() {
+
+    companion object {
+        const val studyBurstArchiveFileName = "tasks"
+        const val answersFilename = "answers"
+        // We exclude the mPower1Email because it contains sensitive user information
+        // That should be stored in the user profile attributes instead
+        val resultExclusionList = listOf(RESULT_IDENTIFIER_MPOWER_1_EMAIL)
+    }
+
+    private val logger = LoggerFactory.getLogger(MpResearchStackArchiveFactory::class.java)
+
+    /**
+     * Can be overridden by sub-class for custom data archiving
+     * @param archiveBuilder fill this builder up with files from the flattenedResultList
+     * @param flattenedResultList read these and add them to the archiveBuilder
+     */
+    override fun addFiles(
+            archiveBuilder: Archive.Builder,
+            flattenedResultList: List<org.researchstack.backbone.result.Result>?,
+            taskIdentifier: String) {
+
+        if (MpIdentifier.STUDY_BURST_COMPLETED_UPLOAD == taskIdentifier) {
+            // Study burst completed marker has custom upload archive names "tasks"
+            // and all results are consolidated into that file with their result identifiers
+            archiveBuilder.addDataFile(fromResultList(studyBurstArchiveFileName, flattenedResultList))
+        } else if (MpIdentifier.STUDY_BURST_REMINDER == taskIdentifier) {
+            // Study burst completed marker has custom upload archive names "answers"
+            // and all results are consolidated into that file with their result identifiers
+            archiveBuilder.addDataFile(fromResultList(answersFilename, flattenedResultList))
+        } else {
+            super.addFiles(archiveBuilder, flattenedResultList, taskIdentifier)
+        }
+    }
+
+    /**
+     * Packages up all the results into a single json archive file
+     * @param filename for the json archive
+     * @param resultList to include all the results in a single json archive
+     */
+    protected fun fromResultList(
+            filename: String,
+            resultList: List<org.researchstack.backbone.result.Result>?): JsonArchiveFile {
+
+        val answerMap = HashMap<String, Any>()
+        resultList?.forEach {
+            MpTaskHelper.addToAnswerMap(this, answerMap, it)
+        }
+
+        // The answer group will not have a valid end date, if one is needed,
+        // consider adding key_endDate as a key/value in answer map above
+        return JsonArchiveFile(filename, DateTime.now(), answerMap)
+    }
+
+    /**
+     * Override to allow for the resultExclusionList to filter out results
+     */
+    override fun fromResult(result: Result): ArchiveFile? {
+        if (resultExclusionList.contains(result.identifier)) {
+            return null
+        }
+        return super.fromResult(result)
+    }
+
+    /**
+     * Due to the nature of the AppCore survey UI being directly coupled to Result types,
+     * We need to override the custom survey answers to tell the archive factory
+     * which types of survey answers or custom result types should be archived as
+     * @param stepResult to transform into a survey answer
+     * @param format the answer format that should be analyzed to make a survey answer
+     * @return a valid SurveyAnswer, or null if conversion is unknown
+     */
+    override fun customSurveyAnswer(stepResult: StepResult<*>, format: AnswerFormat): SurveyAnswer? {
+        if (stepResult.results == null || stepResult.results.isEmpty()) {
+            return null  // question was skipped
+        }
+        if (format is MpBooleanAnswerFormat) {
+            val surveyAnswer = SurveyAnswer.BooleanSurveyAnswer(stepResult)
+            surveyAnswer.questionType = AnswerFormat.Type.Boolean.ordinal
+            surveyAnswer.questionTypeName = AnswerFormat.Type.Boolean.name
+            return surveyAnswer
+        } else if (format is MpTextQuestionBody.AnswerFormat) {
+            val surveyAnswer = SurveyAnswer.TextSurveyAnswer(stepResult)
+            surveyAnswer.questionType = AnswerFormat.Type.Text.ordinal
+            surveyAnswer.questionTypeName = AnswerFormat.Type.Text.name
+            return surveyAnswer
+        } else if (format is MpChoiceAnswerFormat) {
+            val surveyAnswer = SurveyAnswer.ChoiceSurveyAnswer(stepResult)
+            if (format.answerStyle == AnswerFormat.ChoiceAnswerStyle.SingleChoice) {
+                surveyAnswer.questionType = AnswerFormat.Type.SingleChoice.ordinal
+                surveyAnswer.questionTypeName = AnswerFormat.Type.SingleChoice.name
+            } else {
+                surveyAnswer.questionType = AnswerFormat.Type.MultipleChoice.ordinal
+                surveyAnswer.questionTypeName = AnswerFormat.Type.MultipleChoice.name
+            }
+            return surveyAnswer
+        } else if (format is MpIntegerAnswerFormat) {
+            val surveyAnswer = SurveyAnswer.NumericSurveyAnswer<Int>(stepResult)
+            surveyAnswer.questionType = AnswerFormat.Type.Integer.ordinal
+            surveyAnswer.questionTypeName = AnswerFormat.Type.Integer.name
+            return surveyAnswer
+        }
+        return null
+    }
+}

--- a/app/src/main/java/org/sagebionetworks/research/mpower/tracking/TrackingTabFragment.java
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/tracking/TrackingTabFragment.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.research.mpower.tracking;
 
 import static org.researchstack.backbone.ui.fragment.ActivitiesFragment.REQUEST_TASK;
+import static org.sagebionetworks.research.mpower.research.MpIdentifier.BACKGROUND;
 import static org.sagebionetworks.research.mpower.research.MpIdentifier.MOTIVATION;
 import static org.sagebionetworks.research.mpower.research.MpIdentifier.STUDY_BURST_REMINDER;
 import static org.sagebionetworks.research.mpower.studyburst.StudyBurstActivityKt.STUDY_BURST_EXTRA_GUID_OF_TASK_TO_RUN;
@@ -8,7 +9,6 @@ import static org.sagebionetworks.research.mpower.studyburst.StudyBurstActivityK
 
 import android.app.Activity;
 
-import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
 
 import android.content.Context;
@@ -33,6 +33,8 @@ import org.sagebionetworks.research.mobile_ui.show_step.view.SystemWindowHelper;
 import org.sagebionetworks.research.mobile_ui.show_step.view.SystemWindowHelper.Direction;
 import org.sagebionetworks.research.mpower.R;
 import org.sagebionetworks.research.mpower.reminders.StudyBurstReminderActivity;
+import org.sagebionetworks.research.mpower.researchstack.MpResearchStackArchiveFactory;
+import org.sagebionetworks.research.mpower.researchstack.framework.MpDataProvider;
 import org.sagebionetworks.research.mpower.researchstack.framework.MpTaskFactory;
 import org.sagebionetworks.research.mpower.researchstack.framework.MpViewTaskActivity;
 import org.sagebionetworks.research.mpower.researchstack.framework.step.MpSmartSurveyTask;
@@ -304,6 +306,9 @@ public class TrackingTabFragment extends Fragment {
                 if (MOTIVATION.equals(currentSurveySchedule.activityIdentifier())) {
                     // send the user straight into the study burst
                     goToStudyBurst();
+                } else if (BACKGROUND.equals(currentSurveySchedule.activityIdentifier())) {
+                    // Work-around for storing sensitive data from a survey in user attributes
+                    MpDataProvider.getInstance().addUserDataAttributesFromBackgroundSurvey(taskResult);
                 }
                 successfulSurveyUploadTaskId = currentSurveySchedule.activityIdentifier();
             }

--- a/app/src/main/java/org/sagebionetworks/research/mpower/viewmodel/StudyBurstViewModel.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/viewmodel/StudyBurstViewModel.kt
@@ -29,6 +29,8 @@ import org.sagebionetworks.research.mpower.research.MpTaskInfo.Tapping
 import org.sagebionetworks.research.mpower.research.MpTaskInfo.Tremor
 import org.sagebionetworks.research.mpower.research.MpTaskInfo.WalkAndBalance
 import org.sagebionetworks.research.mpower.research.StudyBurstConfiguration
+import org.sagebionetworks.research.mpower.researchstack.MpResearchStackArchiveFactory
+import org.sagebionetworks.research.mpower.researchstack.MpResearchStackArchiveFactory.Companion
 import org.sagebionetworks.research.mpower.researchstack.framework.MpTaskHelper
 import org.sagebionetworks.research.mpower.researchstack.framework.step.body.MpBooleanAnswerFormat
 import org.sagebionetworks.research.mpower.researchstack.framework.step.body.MpChoiceAnswerFormat
@@ -117,9 +119,16 @@ open class StudyBurstViewModel(
     }
 
     init {
-        // TODO: mdephillips 10/20/18 This should actually be set in a single place when
-        // all the dagger injections are done and we have access to the ScheduleRepository
-        scheduleRepo.researchStackUploadArchiveFactory = StudyBurstResearchStackArchiveFactory()
+        // This could be improved by specifying the following lines of code globally after the dagger injections
+        // However, that is done in SageResearchAppSDKModule which has many other dependencies
+        // and I don't think we need to duplicate all these at this time -mdephillips 11/15/18
+        MpResearchStackArchiveFactory.resultExclusionList.forEach {
+            if (!reportRepo.resultExclusionList.contains(it)) {
+                reportRepo.resultExclusionList.add(it)
+            }
+        }
+        val archiveFactory = MpResearchStackArchiveFactory()
+        scheduleRepo.researchStackUploadArchiveFactory = archiveFactory
     }
 
     @VisibleForTesting
@@ -788,95 +797,5 @@ open class StudyBurstSettingsDao @Inject constructor(context: Context) {
         prefs.getString(timestampKey, null)?.let {
             return LocalDateTime.parse(it)
         } ?: return null
-    }
-}
-
-open class StudyBurstResearchStackArchiveFactory: ResearchStackUploadArchiveFactory() {
-
-    private val logger = LoggerFactory.getLogger(StudyBurstResearchStackArchiveFactory::class.java)
-    private val studyBurstArchiveFileName = "tasks"
-    private val answersFilename = "answers"
-
-    /**
-     * Can be overridden by sub-class for custom data archiving
-     * @param archiveBuilder fill this builder up with files from the flattenedResultList
-     * @param flattenedResultList read these and add them to the archiveBuilder
-     */
-    override fun addFiles(
-            archiveBuilder: Archive.Builder,
-            flattenedResultList: List<org.researchstack.backbone.result.Result>?,
-            taskIdentifier: String) {
-
-        if (STUDY_BURST_COMPLETED_UPLOAD == taskIdentifier) {
-            // Study burst completed marker has custom upload archive names "tasks"
-            // and all results are consolidated into that file with their result identifiers
-            archiveBuilder.addDataFile(fromResultList(studyBurstArchiveFileName, flattenedResultList))
-        } else if (STUDY_BURST_REMINDER == taskIdentifier) {
-            // Study burst completed marker has custom upload archive names "answers"
-            // and all results are consolidated into that file with their result identifiers
-            archiveBuilder.addDataFile(fromResultList(answersFilename, flattenedResultList))
-        } else {
-            super.addFiles(archiveBuilder, flattenedResultList, taskIdentifier)
-        }
-    }
-
-    /**
-     * Packages up all the results into a single json archive file
-     * @param filename for the json archive
-     * @param resultList to include all the results in a single json archive
-     */
-    protected fun fromResultList(
-            filename: String,
-            resultList: List<org.researchstack.backbone.result.Result>?): JsonArchiveFile {
-
-        val answerMap = HashMap<String, Any>()
-        resultList?.forEach {
-            MpTaskHelper.addToAnswerMap(this, answerMap, it)
-        }
-
-        // The answer group will not have a valid end date, if one is needed,
-        // consider adding key_endDate as a key/value in answer map above
-        return JsonArchiveFile(filename, DateTime.now(), answerMap)
-    }
-
-    /**
-     * Due to the nature of the AppCore survey UI being directly coupled to Result types,
-     * We need to override the custom survey answers to tell the archive factory
-     * which types of survey answers or custom result types should be archived as
-     * @param stepResult to transform into a survey answer
-     * @param format the answer format that should be analyzed to make a survey answer
-     * @return a valid SurveyAnswer, or null if conversion is unknown
-     */
-    override fun customSurveyAnswer(stepResult: StepResult<*>, format: AnswerFormat): SurveyAnswer? {
-        if (stepResult.results == null || stepResult.results.isEmpty()) {
-            return null  // question was skipped
-        }
-        if (format is MpBooleanAnswerFormat) {
-            val surveyAnswer = SurveyAnswer.BooleanSurveyAnswer(stepResult)
-            surveyAnswer.questionType = AnswerFormat.Type.Boolean.ordinal
-            surveyAnswer.questionTypeName = AnswerFormat.Type.Boolean.name
-            return surveyAnswer
-        } else if (format is MpTextQuestionBody.AnswerFormat) {
-            val surveyAnswer = SurveyAnswer.TextSurveyAnswer(stepResult)
-            surveyAnswer.questionType = AnswerFormat.Type.Text.ordinal
-            surveyAnswer.questionTypeName = AnswerFormat.Type.Text.name
-            return surveyAnswer
-        } else if (format is MpChoiceAnswerFormat) {
-            val surveyAnswer = SurveyAnswer.ChoiceSurveyAnswer(stepResult)
-            if (format.answerStyle == AnswerFormat.ChoiceAnswerStyle.SingleChoice) {
-                surveyAnswer.questionType = AnswerFormat.Type.SingleChoice.ordinal
-                surveyAnswer.questionTypeName = AnswerFormat.Type.SingleChoice.name
-            } else {
-                surveyAnswer.questionType = AnswerFormat.Type.MultipleChoice.ordinal
-                surveyAnswer.questionTypeName = AnswerFormat.Type.MultipleChoice.name
-            }
-            return surveyAnswer
-        } else if (format is MpIntegerAnswerFormat) {
-            val surveyAnswer = SurveyAnswer.NumericSurveyAnswer<Int>(stepResult)
-            surveyAnswer.questionType = AnswerFormat.Type.Integer.ordinal
-            surveyAnswer.questionTypeName = AnswerFormat.Type.Integer.name
-            return surveyAnswer
-        }
-        return null
     }
 }

--- a/researchstack-mpower/src/main/java/org/sagebionetworks/research/mpower/researchstack/framework/MpDataProvider.java
+++ b/researchstack-mpower/src/main/java/org/sagebionetworks/research/mpower/researchstack/framework/MpDataProvider.java
@@ -4,17 +4,34 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 
 import org.researchstack.backbone.DataProvider;
+import org.researchstack.backbone.result.Result;
+import org.researchstack.backbone.result.StepResult;
 import org.researchstack.backbone.result.TaskResult;
 import org.sagebionetworks.bridge.android.manager.BridgeManagerProvider;
 import org.sagebionetworks.bridge.researchstack.BridgeDataProvider;
+import org.sagebionetworks.bridge.researchstack.TaskHelper;
+import org.sagebionetworks.bridge.rest.model.StudyParticipant;
 import org.sagebionetworks.bridge.rest.model.UserSessionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import rx.android.schedulers.AndroidSchedulers;
+import rx.functions.Action1;
+import rx.schedulers.Schedulers;
+import rx.subscriptions.CompositeSubscription;
 
 public class MpDataProvider extends BridgeDataProvider {
 
+    private static final Logger logger = LoggerFactory.getLogger(MpDataProvider.class);
+
+    public static String RESULT_IDENTIFIER_MPOWER_1_EMAIL = "mPower1Email";
     protected MpTaskFactory taskFactory;
+    protected CompositeSubscription compositeSubscription = new CompositeSubscription();
 
     public static MpDataProvider getInstance() {
         DataProvider provider = DataProvider.getInstance();
@@ -44,5 +61,45 @@ public class MpDataProvider extends BridgeDataProvider {
             return new ArrayList<>();
         }
         return sessionInfo.getDataGroups();
+    }
+
+    /**
+     * This is a work-around for storing the result of a survey's question in the user data attributes
+     * Instead of uploading it to synapse or including it in a report
+     * @param taskResult from running the background survey
+     */
+    public void addUserDataAttributesFromBackgroundSurvey(TaskResult taskResult) {
+        Map<String, String> attributes = new HashMap<>();
+        List<Result> flattenedResultList = TaskHelper.flattenResults(taskResult);
+        for (Result result : flattenedResultList) {
+            // Add the mPower1Email as a string to the user attributes map
+            if (RESULT_IDENTIFIER_MPOWER_1_EMAIL.equals(result.getIdentifier()) &&
+                    result instanceof StepResult &&
+                    ((StepResult)result).getResult() instanceof String) {
+                attributes.put(result.getIdentifier(), (String)((StepResult)result).getResult());
+            }
+        }
+        if (!attributes.isEmpty()) {
+            compositeSubscription.add(
+                    updateStudyParticipant(buildParticipantUserDataAttributes(attributes))
+                    .observeOn(Schedulers.io())
+                    .subscribeOn(AndroidSchedulers.mainThread())
+                    .subscribe(userSessionInfo -> {
+                        logger.info("Successfully updated user data attributes for background survey");
+                    }, throwable -> {
+                        logger.warn("Error updating user attributes for background survey " +
+                                throwable.getLocalizedMessage());
+                    }));
+        }
+    }
+
+    private StudyParticipant buildParticipantUserDataAttributes(Map<String, String> userDataAttributes) {
+        StudyParticipant participant = new StudyParticipant();
+        participant.setDataGroups(null);
+        participant.setNotifyByEmail(null);
+        participant.setLanguages(null);
+        participant.setRoles(null);
+        participant.setAttributes(userDataAttributes);
+        return participant;
     }
 }


### PR DESCRIPTION
Added feature for excluding a result id from both synapse upload and reports.  Also added a work-around to save the background survey's "mPower1Email" to a bridge user attribute.

Depends on 
https://github.com/Sage-Bionetworks/BridgeAndroidSDK/pull/194