### PR TITLE
AA-415

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,9 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        // Should target '1.8', but there is currently a bug on Android SDK < 24 that was crashing login
+        // See https://stackoverflow.com/questions/45935788/nosuchmethoderror-java-lang-long-hashcode
+        jvmTarget = '1.6'
     }
 }
 


### PR DESCRIPTION
Crash fix Android SDK < 24 by downgrading kotlin compiler target from 1.8 to 1.6.

This worked for me, I didn't run into any issues with Android Kotlin libraries or anything.  Tested on min SDK 19.