### PR TITLE
Arabara/update to android13

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Nexus_5_API_30.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_33.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-04-28T03:12:23.993912Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-04-28T17:31:54.102942Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
@@ -11,7 +11,7 @@
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-04-28T18:42:38.665587Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-05-15T15:47:12.225111Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-04-28T17:31:54.102942Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-04-28T18:42:38.665587Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Nexus_5_API_27.avd" />
+            <value value="$USER_HOME$/.android/avd/Nexus_5_API_30.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-04-24T18:05:43.002618Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-04-28T03:12:23.993912Z" />
   </component>
 </project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ android:
     - android-28
 
 before_install:
-#  - yes | sdkmanager "platforms;android-31"
   - rvm install 2.7.2
   - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
   - git config --global user.name "Travis CI"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'com.jakewharton.butterknife'
 apply from: '../config/quality/quality.gradle'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion "29.0.3"
     defaultConfig {
         applicationId "org.sagebionetworks.research.mpower"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
 
         // this is not the final version code, product flavors add to it
         versionCode 247

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:name=".MPowerApplication"
         android:allowBackup="false"

--- a/app/src/main/java/org/sagebionetworks/research/mpower/EntryActivity.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/EntryActivity.kt
@@ -34,14 +34,11 @@ package org.sagebionetworks.research.mpower
 
 import android.Manifest
 import android.app.PendingIntent
-import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import dagger.android.support.DaggerAppCompatActivity
@@ -55,8 +52,6 @@ class EntryActivity : DaggerAppCompatActivity() {
     private val LOGGER = LoggerFactory.getLogger(EntryActivity::class.java)
 
     private lateinit var pendingIntent: PendingIntent
-
-    lateinit var sharedPrefs: SharedPreferences
 
     private val passiveGaitViewModel: PassiveGaitViewModel by lazy {
         ViewModelProvider(this).get(PassiveGaitViewModel::class.java)
@@ -95,30 +90,9 @@ class EntryActivity : DaggerAppCompatActivity() {
                     .commitNow()
         }
 
-        requestNotificationPermissions()
-
         setupPendingIntentForActivityTransitions()
 
         passiveGaitViewModel.trackTransitions.observe(this, trackingTransitionsObserver)
-    }
-
-    private fun requestNotificationPermissions() {
-        // Android 13 requires asking a runtime permission for Notifications
-        sharedPrefs = getPreferences(Context.MODE_PRIVATE)
-        val permissionNotGranted = ContextCompat
-                .checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_DENIED
-        val permissionRequested = sharedPrefs
-                .getBoolean(getString(R.string.notification_permissions_asked), false)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-                && permissionNotGranted
-                && !permissionRequested) {
-            requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), 1)
-            with(sharedPrefs.edit()) {
-                putBoolean(getString(R.string.notification_permissions_asked), true)
-                apply()
-            }
-        }
     }
 
     private fun setupPendingIntentForActivityTransitions() {

--- a/app/src/main/java/org/sagebionetworks/research/mpower/EntryActivity.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/EntryActivity.kt
@@ -95,12 +95,21 @@ class EntryActivity : DaggerAppCompatActivity() {
                     .commitNow()
         }
 
+        requestNotificationPermissions()
+
+        setupPendingIntentForActivityTransitions()
+
+        passiveGaitViewModel.trackTransitions.observe(this, trackingTransitionsObserver)
+    }
+
+    private fun requestNotificationPermissions() {
         // Android 13 requires asking a runtime permission for Notifications
         sharedPrefs = getPreferences(Context.MODE_PRIVATE)
         val permissionNotGranted = ContextCompat
                 .checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_DENIED
         val permissionRequested = sharedPrefs
                 .getBoolean(getString(R.string.notification_permissions_asked), false)
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
                 && permissionNotGranted
                 && !permissionRequested) {
@@ -110,10 +119,6 @@ class EntryActivity : DaggerAppCompatActivity() {
                 apply()
             }
         }
-
-        setupPendingIntentForActivityTransitions()
-
-        passiveGaitViewModel.trackTransitions.observe(this, trackingTransitionsObserver)
     }
 
     private fun setupPendingIntentForActivityTransitions() {

--- a/app/src/main/java/org/sagebionetworks/research/mpower/inject/MpShowOverviewStepFragment.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/inject/MpShowOverviewStepFragment.kt
@@ -91,7 +91,8 @@ class MpShowOverviewStepFragment: ShowOverviewStepFragment() {
      */
     protected fun onReminderMeLaterClicked() {
         context?.let {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && ContextCompat.checkSelfPermission(it, Manifest.permission.POST_NOTIFICATIONS)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                    && ContextCompat.checkSelfPermission(it, Manifest.permission.POST_NOTIFICATIONS)
                     != PackageManager.PERMISSION_GRANTED) {
                 startEnableNotificationsProcess()
                 return

--- a/app/src/main/java/org/sagebionetworks/research/mpower/inject/MpShowOverviewStepFragment.kt
+++ b/app/src/main/java/org/sagebionetworks/research/mpower/inject/MpShowOverviewStepFragment.kt
@@ -100,7 +100,7 @@ class MpShowOverviewStepFragment: ShowOverviewStepFragment() {
      * This function is called when the user taps the
      * "Remind me later" skip button action at the bottom of the screen
      */
-    protected fun onReminderMeLaterClicked() {
+    private fun onReminderMeLaterClicked() {
         val permissionRequested = sharedPrefs
                 .getBoolean(getString(R.string.notification_permissions_asked), false)
         val permissionNotGranted = ContextCompat.checkSelfPermission(myContext, Manifest.permission.POST_NOTIFICATIONS) !=

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,10 @@
         <item quantity="other">%d Doses.</item>
     </plurals>
 
+    <!-- Post Notification Permissions Strings -->
+    <string name="reminder_post_notifications">Please enable Post Notifications in Settings</string>
+    <string name="notification_permissions_asked">POST_NOTIFICATIONS_ASKED</string>
+
     <!-- Today Fragment -->
     <!-- The term to use when referring to multiple instances of a task, such as when describing-->
     <!-- how may times the user has logged taking medication.-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,7 +165,7 @@
 
     <!-- Post Notification Permissions Strings -->
     <string name="reminder_post_notifications">Please enable Post Notifications in Settings</string>
-    <string name="notification_permissions_asked">POST_NOTIFICATIONS_ASKED</string>
+    <string name="notification_permissions_asked">NOTIFICATION_PERMISSIONS_ASKED</string>
 
     <!-- Today Fragment -->
     <!-- The term to use when referring to multiple instances of a task, such as when describing-->


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-908

The only relevant change to upgrade mPower-2.0 to target Android 13/API 33 is that Android 13 requires a runtime permission to be granted for POST_NOTIFICATIONS. API 32 only effects large screened devices, so unless we are worried about tablets and foldable devices then upgrading to API 32 requires no changes from the mPower-2.0 version that targets API 31. 

The added code only pertains to Android 13+. I have added logic to request POST_NOTIFICATION permissions the very first time a user tries to set a reminder, all future requests to set a reminder will direct the user to the app's notification settings if the POST_NOTIFICATION permission is not already granted.